### PR TITLE
Refactoring of user deletion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,10 @@
        {
          "language": "javascript",
          "autoFix": true
+       },
+       {
+         "language": "typescript",
+         "autoFix": true
        }
      ],
      "vetur.format.defaultFormatter.js": "vscode-typescript",

--- a/api/app.py
+++ b/api/app.py
@@ -20,7 +20,6 @@ from werkzeug.utils import import_string
 import requests
 from utils.defaults import Reel2bitsDefaults
 import commands
-from flask_sqlalchemy import models_committed
 
 from models import db, Config, user_datastore, create_actor
 from utils.various import InvalidUsage, is_admin, add_user_log, join_url
@@ -242,13 +241,6 @@ def create_app(config_filename="config.development.Config", app_name=None, regis
         response = jsonify(error.to_dict())
         response.status_code = error.status_code
         return response
-
-    # Execute extra function if defined when DELETE COMMIT
-    @models_committed.connect_via(app)
-    def on_models_committed(sender, changes):
-        for obj, change in changes:
-            if change == "delete" and hasattr(obj, "__commit_delete__"):
-                obj.__commit_delete__()
 
     sounds = UploadSet("sounds", AUDIO)
     configure_uploads(app, sounds)

--- a/api/app.py
+++ b/api/app.py
@@ -20,6 +20,7 @@ from werkzeug.utils import import_string
 import requests
 from utils.defaults import Reel2bitsDefaults
 import commands
+from flask_sqlalchemy import models_committed
 
 from models import db, Config, user_datastore, create_actor
 from utils.various import InvalidUsage, is_admin, add_user_log, join_url
@@ -241,6 +242,12 @@ def create_app(config_filename="config.development.Config", app_name=None, regis
         response = jsonify(error.to_dict())
         response.status_code = error.status_code
         return response
+
+    @models_committed.connect_via(app)
+    def on_models_committed(sender, changes):
+        for obj, change in changes:
+            if change == "delete" and hasattr(obj, "__commit_delete__"):
+                obj.__commit_delete__()
 
     sounds = UploadSet("sounds", AUDIO)
     configure_uploads(app, sounds)

--- a/api/app.py
+++ b/api/app.py
@@ -243,6 +243,7 @@ def create_app(config_filename="config.development.Config", app_name=None, regis
         response.status_code = error.status_code
         return response
 
+    # Execute extra function if defined when DELETE COMMIT
     @models_committed.connect_via(app)
     def on_models_committed(sender, changes):
         for obj, change in changes:

--- a/api/controllers/api/v1/accounts.py
+++ b/api/controllers/api/v1/accounts.py
@@ -752,6 +752,10 @@ def account_delete():
     user_id = current_user.id
     email = current_user.email
 
+    # Revoke Oauth2 credentials
+    for oa2_token in OAuth2Token.query.filter(OAuth2Token.user_id == current_user.id).all():
+        oa2_token.revoked = True
+
     # set all activities as deleted
     activities = Activity.query.filter(Activity.actor == current_user.actor[0].id)
     for activity in activities.all():

--- a/api/controllers/api/v1/accounts.py
+++ b/api/controllers/api/v1/accounts.py
@@ -724,3 +724,31 @@ def following(user_id):
 
     resp = {"page": page, "page_size": count, "totalItems": q.total, "items": followings, "totalPages": q.pages}
     return jsonify(resp)
+
+
+@bp_api_v1_accounts.route("/api/v1/accounts", methods=["DELETE"])
+@require_oauth("write")
+def account_delete():
+    """
+    Delete account
+    ---
+    tags:
+        - Accounts
+    responses:
+      200:
+        description: Returns user username
+    """
+    current_user = current_token.user
+    if not current_user:
+        abort(400)
+
+    # store a few infos
+    username = current_user.name
+    # user_id = current_user.id
+    # email = current_user.email
+
+    # Delete user
+    # Propagage a Delete of each federated tracks
+    # mark actor as deleted
+
+    return jsonify({"username": username}), 200

--- a/api/controllers/api/v1/accounts.py
+++ b/api/controllers/api/v1/accounts.py
@@ -6,7 +6,7 @@ from app_oauth import authorization, require_oauth
 from authlib.flask.oauth2 import current_token
 from datas_helpers import to_json_track, to_json_account, to_json_relationship
 from utils.various import forbidden_username, add_user_log, add_log
-from tasks import send_update_profile
+from tasks import send_update_profile, federate_delete_actor
 import re
 from sqlalchemy import or_
 from flask_mail import Message
@@ -759,7 +759,8 @@ def account_delete():
 
     # set actor as deleted and federate a Delete(Actor)
     current_user.actor[0].meta_deleted = True
-    # TODO FIXME: Federate Delete(Actor)
+    # Federate Delete(Actor)
+    federate_delete_actor(current_user.actor[0])
 
     # drop all relations
     follows = Follower.query.filter(

--- a/api/controllers/api/v1/ap.py
+++ b/api/controllers/api/v1/ap.py
@@ -13,23 +13,25 @@ bp_ap = Blueprint("bp_ap", __name__)
 
 @bp_ap.route("/user/<string:name>", methods=["GET"])
 def user_actor_json(name):
-    actor = Actor.query.filter(Actor.preferred_username == name, Actor.domain == current_app.config["AP_DOMAIN"]).one()
+    actor = Actor.query.filter(
+        Actor.preferred_username == name, Actor.domain == current_app.config["AP_DOMAIN"]
+    ).first()
     if not actor:
-        return Response("", status=404)
+        return Response("", status=404, mimetype="application/activity+json; charset=utf-8")
 
     if not actor.meta_deleted:
         response = jsonify(actor.to_dict())
     else:
         # Get the tombstone
-        tomb = Activity.query.filter(
-            Activity.type == "Delete",
-            Activity.box == "outbox",
-            Activity.local.is_(True),
-            Activity.actor == actor.id,
-            Activity.payload[("object", "type")].astext == "Tombstone",
-            Activity.payload[("object", "id")].astext == actor.url,
-        ).one()
-        response = jsonify(tomb.payload)
+        # tomb = Activity.query.filter(
+        #     Activity.type == "Delete",
+        #     Activity.box == "outbox",
+        #     Activity.local.is_(True),
+        #     Activity.actor == actor.id,
+        #     Activity.payload[("object", "type")].astext == "Tombstone",
+        #     Activity.payload[("object", "id")].astext == actor.url,
+        # ).one()
+        return Response(response="", status=410, mimetype="application/activity+json; charset=utf-8")
 
     response.mimetype = "application/activity+json; charset=utf-8"
     return response

--- a/api/migrations/versions/54_90ebd28ef06b_.py
+++ b/api/migrations/versions/54_90ebd28ef06b_.py
@@ -1,0 +1,35 @@
+"""Remove timeline table
+
+Revision ID: 90ebd28ef06b
+Revises: 6cd62c61bc1a
+Create Date: 2019-10-02 12:51:50.465763
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "90ebd28ef06b"
+down_revision = "6cd62c61bc1a"
+
+from alembic import op  # noqa: E402
+import sqlalchemy as sa  # noqa: E402
+from sqlalchemy.dialects import postgresql  # noqa: E402
+
+
+def upgrade():
+    op.drop_table("timeline")
+
+
+def downgrade():
+    op.create_table(
+        "timeline",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column("timestamp", postgresql.TIMESTAMP(), autoincrement=False, nullable=True),
+        sa.Column("private", sa.BOOLEAN(), autoincrement=False, nullable=True),
+        sa.Column("sound_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("album_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("user_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(["album_id"], ["album.id"], name="timeline_album_id_fkey"),
+        sa.ForeignKeyConstraint(["sound_id"], ["user.id"], name="timeline_sound_id_fkey"),
+        sa.ForeignKeyConstraint(["user_id"], ["sound.id"], name="timeline_user_id_fkey"),
+        sa.PrimaryKeyConstraint("id", name="timeline_pkey"),
+    )

--- a/api/migrations/versions/55_02912cfac79c_.py
+++ b/api/migrations/versions/55_02912cfac79c_.py
@@ -1,0 +1,22 @@
+"""Add meta_deleted flag to Actors
+
+Revision ID: 02912cfac79c
+Revises: 90ebd28ef06b
+Create Date: 2019-10-02 13:05:13.668151
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "02912cfac79c"
+down_revision = "90ebd28ef06b"
+
+from alembic import op  # noqa: E402
+import sqlalchemy as sa  # noqa: E402
+
+
+def upgrade():
+    op.add_column("actor", sa.Column("meta_deleted", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("actor", "meta_deleted")

--- a/api/models.py
+++ b/api/models.py
@@ -487,6 +487,8 @@ class Actor(db.Model):
     # two relations. This may be better than only one, and some hackish things
     # by querying directly the old db.Table definition
 
+    meta_deleted = db.Column(db.Boolean, default=False)
+
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     user = db.relationship("User", backref=db.backref("actor"))
 

--- a/api/models.py
+++ b/api/models.py
@@ -112,7 +112,7 @@ class User(db.Model, UserMixin):
     # Relations
 
     roles = db.relationship(
-        "Role", secondary=roles_users, backref=db.backref("users", lazy="dynamic"), cascade="delete"
+        "Role", secondary=roles_users, backref=db.backref("users", lazy="dynamic"), cascade_backrefs=False
     )
     password_reset_tokens = db.relationship("PasswordResetToken", backref="user", lazy="dynamic", cascade="delete")
     user_loggings = db.relationship("UserLogging", backref="user", lazy="dynamic", cascade="delete")

--- a/api/models.py
+++ b/api/models.py
@@ -342,6 +342,15 @@ class Sound(db.Model):
             return False
         return self.processing_done() and infos.done_basic
 
+    # Delete transcoding file when COMMIT DELETE
+    def __commit_delete__(self):
+        if self.transcode_needed:
+            fname = os.path.join(current_app.config["UPLOADED_SOUNDS_DEST"], self.path_sound(orig=False))
+            if os.path.isfile(fname):
+                os.unlink(fname)
+            else:
+                print(f"!!! COMMIT DELETE cannot delete file {fname}")
+
 
 class Album(db.Model):
     __tablename__ = "album"

--- a/api/models.py
+++ b/api/models.py
@@ -111,7 +111,9 @@ class User(db.Model, UserMixin):
 
     # Relations
 
-    roles = db.relationship("Role", secondary=roles_users, backref=db.backref("users", lazy="dynamic"))
+    roles = db.relationship(
+        "Role", secondary=roles_users, backref=db.backref("users", lazy="dynamic"), cascade="delete"
+    )
     password_reset_tokens = db.relationship("PasswordResetToken", backref="user", lazy="dynamic", cascade="delete")
     user_loggings = db.relationship("UserLogging", backref="user", lazy="dynamic", cascade="delete")
     loggings = db.relationship("Logging", backref="user", lazy="dynamic", cascade="delete")
@@ -305,8 +307,6 @@ class Sound(db.Model):
     activity_id = db.Column(db.Integer(), db.ForeignKey("activity.id"), nullable=True)
     activity = db.relationship("Activity")
 
-    timeline = db.relationship("Timeline", uselist=False, back_populates="sound")
-
     __mapper_args__ = {"order_by": uploaded.desc()}
 
     def elapsed(self):
@@ -360,30 +360,11 @@ class Album(db.Model):
 
     flake_id = db.Column(UUID(as_uuid=True), unique=False, nullable=True)
 
-    timeline = db.relationship("Timeline", uselist=False, back_populates="album")
-
     __mapper_args__ = {"order_by": created.desc()}
 
     def elapsed(self):
         el = datetime.datetime.utcnow() - self.created
         return el.total_seconds()
-
-
-class Timeline(db.Model):
-    __tablename__ = "timeline"
-
-    id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(db.DateTime(timezone=False), default=datetime.datetime.utcnow)
-    private = db.Column(db.Boolean, default=False)
-
-    sound_id = db.Column(db.Integer(), db.ForeignKey("user.id"), nullable=False)
-    album_id = db.Column(db.Integer(), db.ForeignKey("album.id"), nullable=False)
-    user_id = db.Column(db.Integer(), db.ForeignKey("sound.id"), nullable=False)
-
-    album = db.relationship("Album", back_populates="timeline")
-    sound = db.relationship("Sound", back_populates="timeline")
-
-    __mapper_args__ = {"order_by": timestamp.desc()}
 
 
 @event.listens_for(Sound, "after_update")

--- a/api/models.py
+++ b/api/models.py
@@ -301,10 +301,12 @@ class Sound(db.Model):
 
     flake_id = db.Column(UUID(as_uuid=True), unique=False, nullable=True)
 
+    # relations
     user_id = db.Column(db.Integer(), db.ForeignKey("user.id"), nullable=False)
     album_id = db.Column(db.Integer(), db.ForeignKey("album.id"), nullable=True)
-    sound_infos = db.relationship("SoundInfo", backref="sound_info", lazy="dynamic", cascade="delete")
     activity_id = db.Column(db.Integer(), db.ForeignKey("activity.id"), nullable=True)
+
+    sound_infos = db.relationship("SoundInfo", backref="sound_info", lazy="dynamic", cascade="delete")
     activity = db.relationship("Activity")
 
     __mapper_args__ = {"order_by": uploaded.desc()}
@@ -355,10 +357,11 @@ class Album(db.Model):
     private = db.Column(db.Boolean(), default=False, nullable=True)
     slug = db.Column(db.String(255), unique=True, nullable=True)
 
+    flake_id = db.Column(UUID(as_uuid=True), unique=False, nullable=True)
+
+    # relations
     user_id = db.Column(db.Integer(), db.ForeignKey("user.id"), nullable=False)
     sounds = db.relationship("Sound", backref="album", lazy="dynamic")
-
-    flake_id = db.Column(UUID(as_uuid=True), unique=False, nullable=True)
 
     __mapper_args__ = {"order_by": created.desc()}
 

--- a/api/models.py
+++ b/api/models.py
@@ -344,6 +344,7 @@ class Sound(db.Model):
 
     # Delete files file when COMMIT DELETE
     def __commit_delete__(self):
+        print("COMMIT DELETE: Deleting files")
         fname = os.path.join(current_app.config["UPLOADED_SOUNDS_DEST"], self.path_sound(orig=True))
         if os.path.isfile(fname):
             os.unlink(fname)
@@ -405,6 +406,11 @@ def generate_sound_flakeid(mapper, connection, target):
     if not target.flake_id:
         flake_id = uuid.UUID(int=gen_flakeid())
         connection.execute(Sound.__table__.update().where(Sound.__table__.c.id == target.id).values(flake_id=flake_id))
+
+
+@event.listens_for(Sound, "after_delete")
+def delete_files(mapper, connection, target):
+    target.__commit_delete__()
 
 
 @event.listens_for(Album, "after_update")

--- a/api/models.py
+++ b/api/models.py
@@ -342,14 +342,20 @@ class Sound(db.Model):
             return False
         return self.processing_done() and infos.done_basic
 
-    # Delete transcoding file when COMMIT DELETE
+    # Delete files file when COMMIT DELETE
     def __commit_delete__(self):
+        fname = os.path.join(current_app.config["UPLOADED_SOUNDS_DEST"], self.path_sound(orig=True))
+        if os.path.isfile(fname):
+            os.unlink(fname)
+        else:
+            print(f"!!! COMMIT DELETE cannot delete orig file {fname}")
+
         if self.transcode_needed:
             fname = os.path.join(current_app.config["UPLOADED_SOUNDS_DEST"], self.path_sound(orig=False))
             if os.path.isfile(fname):
                 os.unlink(fname)
             else:
-                print(f"!!! COMMIT DELETE cannot delete file {fname}")
+                print(f"!!! COMMIT DELETE cannot delete transcoded file {fname}")
 
 
 class Album(db.Model):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -27,5 +27,6 @@ flasgger==0.9.3
 pymediainfo==4.1
 feedgen==0.8.0
 waitress==1.3.1
+Flask-SQLAlchemy==2.4.0
 git+https://github.com/jwag956/flask-security#egg=Flask-Security-too
 git+https://github.com/rhaamo/little-boxes@reel2bits#egg=little-boxes

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -29,4 +29,4 @@ feedgen==0.8.0
 waitress==1.3.1
 Flask-SQLAlchemy==2.4.0
 git+https://github.com/jwag956/flask-security#egg=Flask-Security-too
-git+https://github.com/rhaamo/little-boxes@reel2bits#egg=little-boxes
+git+https://github.com/tsileo/little-boxes@master#egg=little-boxes

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -92,9 +92,9 @@ def federate_delete_actor(actor: Actor) -> None:
 
     actor = actor.to_dict()
     # Create delete
-    # Somehow we needs to add /activity here
+    # No need for '/activity' here ?
     # FIXME do that better
-    delete = ap.Delete(actor=actor, object=ap.Tombstone(id=actor["id"] + "/activity").to_dict(embed=True))
+    delete = ap.Delete(actor=actor, object=ap.Tombstone(id=actor["id"]).to_dict(embed=True))
     # Federate
     post_to_outbox(delete)
 

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -67,6 +67,8 @@ def federate_delete_sound(sound: Sound) -> None:
     if not current_app.config["AP_ENABLED"]:
         return
 
+    # TODO FIXME: to who is the delete sent ?
+
     actor = sound.user.actor[0].to_dict()
     # Get activity
     # Create delete
@@ -78,6 +80,21 @@ def federate_delete_sound(sound: Sound) -> None:
     delete = ap.Delete(
         actor=actor, object=ap.Tombstone(id=sound.activity.payload["id"] + "/activity").to_dict(embed=True)
     )
+    # Federate
+    post_to_outbox(delete)
+
+
+def federate_delete_actor(actor: Actor) -> None:
+    if not current_app.config["AP_ENABLED"]:
+        return
+
+    # TODO FIXME: to who is the delete sent ?
+
+    actor = actor.to_dict()
+    # Create delete
+    # Somehow we needs to add /activity here
+    # FIXME do that better
+    delete = ap.Delete(actor=actor, object=ap.Tombstone(id=actor["id"] + "/activity").to_dict(embed=True))
     # Federate
     post_to_outbox(delete)
 

--- a/api/templates/email/account_deleted.html
+++ b/api/templates/email/account_deleted.html
@@ -1,0 +1,3 @@
+<p>Hello {{ username }}!</p>
+
+<p>Your account have been successfully deleted.</p>

--- a/api/templates/email/account_deleted.txt
+++ b/api/templates/email/account_deleted.txt
@@ -1,0 +1,3 @@
+Hello {{ username }}!
+
+Your account have been successfully deleted.

--- a/front/src/components/sidebar/sidebar.vue
+++ b/front/src/components/sidebar/sidebar.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <template v-if="currentUser">
-      <UserCard :user="currentUser" />
-      <template v-if="currentUser.reel2bits.quota_limit > 0">
+    <template v-if="displayUser">
+      <UserCard :user="displayUser" />
+      <template v-if="isUs && displayUser.reel2bits.quota_limit > 0">
         <div class="card mb-4">
           <div class="card-body py-3 px-3">
             <translate translate-context="Content/UserProfile/Sidebar/Quota" :translate-params="{quotaSlashRepr: humanQuota}">
@@ -26,23 +26,31 @@ const Sidebar = {
     UserCard,
     Footer
   },
+  props: [
+    'user'
+  ],
   computed: {
     currentUser () { return this.$store.state.users.currentUser },
+    displayUser () { return this.user || this.currentUser },
+    isUs () {
+      return this.displayUser && this.$store.state.users.currentUser.id &&
+        this.displayUser.id === this.$store.state.users.currentUser.id
+    },
     humanQuota () {
       let quotaCount = ''
       let quotaLimit = ''
 
-      if (this.currentUser.reel2bits.quota_count === 0) {
+      if (this.displayUser.reel2bits.quota_count === 0) {
         quotaCount = '0'
       } else {
-        let ffs = fileSizeFormatService.fileSizeFormat(this.currentUser.reel2bits.quota_count)
+        let ffs = fileSizeFormatService.fileSizeFormat(this.displayUser.reel2bits.quota_count)
         quotaCount = ffs.num + ffs.unit
       }
 
-      if (this.currentUser.reel2bits.quota_limit === 0) {
+      if (this.displayUser.reel2bits.quota_limit === 0) {
         quotaLimit = '0'
       } else {
-        let ffs = fileSizeFormatService.fileSizeFormat(this.currentUser.reel2bits.quota_limit)
+        let ffs = fileSizeFormatService.fileSizeFormat(this.displayUser.reel2bits.quota_limit)
         quotaLimit = ffs.num + ffs.unit
       }
 

--- a/front/src/components/user_profile/user_profile.vue
+++ b/front/src/components/user_profile/user_profile.vue
@@ -59,7 +59,7 @@
           />
         </div>
         <div class="col-md-4">
-          <Sidebar />
+          <Sidebar :user="user" />
         </div>
       </div>
     </div>

--- a/front/src/components/user_settings/user_settings.vue
+++ b/front/src/components/user_settings/user_settings.vue
@@ -2,6 +2,7 @@
   <div class="row justify-content-md-center">
     <div class="col-md-6">
       <b-tabs content="mt-3">
+        <!-- settings -->
         <b-tab :title="labels.userSettingsTab">
           <b-alert v-if="saveError" variant="danger" show>
             <span v-translate translate-context="Content/UserSettings/Alert/Error saving">Error saving settings.</span>
@@ -68,6 +69,8 @@
             </b-button>
           </b-form>
         </b-tab>
+
+        <!-- security -->
         <b-tab :title="labels.securityTab">
           <b-form-group
             id="ig-password0"
@@ -128,10 +131,34 @@
             {{ changePasswordError }}
           </p>
         </b-tab>
+
+        <!-- account -->
+        <b-tab :title="labels.accountTab">
+          <b-button v-b-modal.modal-delete
+                    variant="danger"
+          >
+            <i class="fa fa-times" aria-hidden="true" /> <translate translate-context="Content/UserSettings/Button">
+              Delete my account
+            </translate>
+          </b-button>
+          <b-modal id="modal-delete" :title="labels.deleteAccountModalTitle" @ok="deleteAccount">
+            <p v-translate class="my-4" translate-context="Content/UserSettings/Modal/Delete/Content">
+              Are you sure you want to delete your account ?
+              <br>
+              All associated datas will be permanently deleted.
+            </p>
+          </b-modal>
+        </b-tab>
       </b-tabs>
     </div>
   </div>
 </template>
+
+<style lang="scss">
+ul.nav-tabs {
+  margin-bottom: .5em;
+}
+</style>
 
 <script>
 import { validationMixin } from 'vuelidate'
@@ -173,7 +200,9 @@ export default {
         bioLabel: this.$pgettext('Content/UserSettings/Input.Label/Bio', 'Bio (optional):'),
         bioPlaceholder: this.$pgettext('Content/UserSettings/Input.Placeholder/Bio', "quack quack I'm a cat").replace(/\s*\n\s*/g, ' \n'),
         userSettingsTab: this.$pgettext('Content/UserSettings/Tabs/Label', 'User settings'),
-        securityTab: this.$pgettext('Content/UserSettings/Tabs/Label', 'Security')
+        securityTab: this.$pgettext('Content/UserSettings/Tabs/Label', 'Security'),
+        accountTab: this.$pgettext('Content/UserSettings/Tabs/Label', 'Account'),
+        deleteAccountModalTitle: this.$pgettext('Content/UserSettings/Modal/Title', 'Account deletion')
       }
     }
   },
@@ -245,6 +274,29 @@ export default {
     logout () {
       this.$store.dispatch('logout')
       this.$router.replace('/')
+    },
+    async deleteAccount () {
+      console.log('deleting account')
+      await this.$store.state.api.backendInteractor.deleteUser({ userId: this.currentUser.id })
+        .then(() => {
+          console.log('account deletion queued')
+          this.$bvToast.toast(this.$pgettext('Content/UserSettings/Toast/Error/Message', 'Action in progress'), {
+            title: this.$pgettext('Content/UserSettings/Toast/Error/Title', 'Account deletion'),
+            autoHideDelay: 10000,
+            appendToast: false,
+            variant: 'success'
+          })
+          this.logout()
+        })
+        .catch((e) => {
+          console.log('an error occured', e)
+          this.$bvToast.toast(this.$pgettext('Content/UserSettings/Toast/Error/Message', 'An error occured while deleting the account'), {
+            title: this.$pgettext('Content/UserSettings/Toast/Error/Title', 'Account deletion'),
+            autoHideDelay: 20000,
+            appendToast: false,
+            variant: 'danger'
+          })
+        })
     }
   }
 }

--- a/front/src/services/api/api.service.js
+++ b/front/src/services/api/api.service.js
@@ -546,6 +546,21 @@ const fetchFollowers = ({ id, page = 1, limit = 20, credentials }) => {
     })
 }
 
+const deleteUser = ({ userId, credentials }) => {
+  const headers = authHeaders(credentials)
+  return fetch(MASTODON_USER_URL, {
+    method: 'DELETE',
+    headers: headers
+  })
+    .then((data) => {
+      if (data.ok) {
+        return data
+      }
+      throw new Error('Error queuing user deletion', data)
+    })
+    .then((data) => data.json())
+}
+
 const apiService = {
   verifyCredentials,
   register,
@@ -574,7 +589,8 @@ const apiService = {
   followUser,
   unfollowUser,
   fetchFriends,
-  fetchFollowers
+  fetchFollowers,
+  deleteUser
 }
 
 export default apiService

--- a/front/src/services/backend_interactor_service/backend_interactor_service.js
+++ b/front/src/services/backend_interactor_service/backend_interactor_service.js
@@ -134,8 +134,8 @@ const backendInteractorService = credentials => {
   }
 
   // eslint-disable-next-line camelcase
-  const deleteUser = ({ screen_name }) => {
-    return apiService.deleteUser({ screen_name, credentials })
+  const deleteUser = ({ userId }) => {
+    return apiService.deleteUser({ userId, credentials })
   }
 
   const vote = (pollId, choices) => {


### PR DESCRIPTION
Plan:
- [x] Add a link with modal validation in user settings, new pane "account", to delete account
- Deleting the User should:
  - [x] delete associated "CASCADE": UserLogging, Logging, Sound, Album, PasswordResetToken
  - [x] delete all associated OAuth tokens (three tables)
  - [x] create Actor.meta_deleted
  - [x] send a Delete for the Actor
  - [x] set actor deleted=True, and purge some infos
  - [x] set all related Activity at deleted=True, and purge some infos
  - [x] remove all Following relations
  - [x] send an email saying the account have been correctly deleted
  - [x] accessing an activity should return a Tombstone
  - [x] accessing the actor should return a Tombstone

Bugs:
- [x] user deletion also delete the Role (should only the relationship)
- [x] registration issue ?
- [x] follow relationship not deleted