### PR TITLE
Bump docker base image to node:12

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11
+FROM node:12
 
 # needed to compile translations
 RUN curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x /usr/local/bin/jq


### PR DESCRIPTION
**What does this Pull Request do**

This pull request bump the node version used in the frontend Dockerfile from `node:11` to `node:12`.